### PR TITLE
API Tokens, adds the ability to handle the API without expiration

### DIFF
--- a/src/components/atoms/BoxToken/BoxToken.tsx
+++ b/src/components/atoms/BoxToken/BoxToken.tsx
@@ -37,20 +37,26 @@ const renderToken = (token: ApiToken, key: number, total: number) => (
     <td>
       <span
         title={
-          isDateAfterNow(token.exp)
-            ? ''
-            : moment(token.exp).format('MM/DD/YYYY hh:mm a')
+          token.exp
+            ? isDateAfterNow(token.exp)
+              ? ''
+              : moment(token.exp).format('MM/DD/YYYY hh:mm a')
+            : 'Never'
         }
         className={classNames(
           'BoxToken__item__date',
-          isDateAfterNow(token.exp)
-            ? 'BoxToken__item__date__expired'
-            : 'BoxToken__item__date__help'
+          token.exp
+            ? isDateAfterNow(token.exp)
+              ? 'BoxToken__item__date__expired'
+              : 'BoxToken__item__date__help'
+            : ''
         )}
       >
-        {isDateAfterNow(token.exp)
-          ? moment(token.exp).format('MM/DD/YYYY hh:mm a')
-          : moment(token.exp).fromNow()}
+        {token.exp
+          ? isDateAfterNow(token.exp)
+            ? moment(token.exp).format('MM/DD/YYYY hh:mm a')
+            : moment(token.exp).fromNow()
+          : 'Never'}
       </span>
     </td>
     <td>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ export const parseJwt = (token: string): JWT => {
   const parsedToken = JSON.parse(window.atob(base64))
   return {
     iat: timestampToDateJS(parsedToken.iat),
-    ...(parsedToken.exp && { exp: timestampToDateJS(parsedToken.exp) })
+    exp: parsedToken.exp && timestampToDateJS(parsedToken.exp)
   }
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ export const parseJwt = (token: string): JWT => {
   const parsedToken = JSON.parse(window.atob(base64))
   return {
     iat: timestampToDateJS(parsedToken.iat),
-    exp: timestampToDateJS(parsedToken.exp)
+    ...(parsedToken.exp && { exp: timestampToDateJS(parsedToken.exp) })
   }
 }
 

--- a/src/interfaces/Props.ts
+++ b/src/interfaces/Props.ts
@@ -47,5 +47,5 @@ export interface FrostState {
 
 export interface JWT {
   readonly iat: Date
-  readonly exp: Date
+  readonly exp?: Date
 }

--- a/src/interfaces/Props.ts
+++ b/src/interfaces/Props.ts
@@ -47,5 +47,5 @@ export interface FrostState {
 
 export interface JWT {
   readonly iat: Date
-  readonly exp?: Date
+  readonly exp: Date
 }


### PR DESCRIPTION
This PR introduces

- Shows the legend never when the API Token does not have expiration property

Note: This functionality requires be tested. The functionality in the API needs to deployed in the server testing.

fix #40 
