### PR TITLE
Fix, return typeof GetApiTokensFrost

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@poetapp/frost-client": "^0.1.1",
+    "@poetapp/frost-client": "^0.1.4",
     "classnames": "^2.2.5",
     "formdata-polyfill": "^3.0.9",
     "isomorphic-fetch": "^2.2.1",

--- a/src/sagas/GetApiTokens.ts
+++ b/src/sagas/GetApiTokens.ts
@@ -3,9 +3,9 @@ import { Actions } from 'actions/index'
 import { SagaIterator } from 'redux-saga'
 import { call, takeLatest, put, ForkEffect } from 'redux-saga/effects'
 
-// TODO we have to update Frost client, now Frost client returns
-// { apiToken: '', dateCreate: ''} instead of { apiTokens: [string] }
-async function GetApiTokensFrost(apiToken: string): Promise<any> {
+async function GetApiTokensFrost(
+  apiToken: string
+): Promise<{ readonly apiTokens: ReadonlyArray<string> }> {
   const frost = new Frost({ host: '/api' })
   return await frost.getApiTokens(apiToken)
 }


### PR DESCRIPTION
This PR introduces

- fixes return typeof GetApiTokensFrost
- updates Frost client to 0.1.4

Note: This fix needs publish the new version 0.1.4 of Frost Client
