### PR TITLE
adds @po.et/tslint-rules and scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,60 @@
       "integrity": "sha512-jy8eFnMm3EMkAsCd7B7Csz8AW2TmV3zapXbJB6Z8Pr8AWNaudm+MdBCfoUStE1i/PcpdkutnwZqmr12LJbbVdg==",
       "dev": true
     },
+    "@po.et/tslint-rules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@po.et/tslint-rules/-/tslint-rules-1.0.0.tgz",
+      "integrity": "sha512-XMj++zPLEmhlmIPNIlunJMuu6hPHK+TCR8mYzfTiF1ht7bEHGVA16olvGqJmvfUvA5Di5CStPsV7Kr1HWhx9Dw==",
+      "dev": true,
+      "requires": {
+        "prettier": "1.12.1",
+        "tslint": "5.9.1",
+        "tslint-config-prettier": "1.12.0",
+        "tslint-eslint-rules": "5.1.0",
+        "tslint-immutable": "4.5.4",
+        "tslint-plugin-prettier": "1.3.0"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
+          "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+          "dev": true
+        },
+        "tslint-config-prettier": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.12.0.tgz",
+          "integrity": "sha512-7zugK8NWpoDPYT6UNGLDGpQOhk0CSodjkyrTNiHOCjwIAleYKlyQunxpsSXBIoGEs/kFVppd6YzZeQZtrJnyRg==",
+          "dev": true
+        },
+        "tslint-eslint-rules": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.1.0.tgz",
+          "integrity": "sha512-lNIaLDymwts58SmocvVxzY9DSDONwZhHMt8T0J4uFMQV4jgYMMAFa89oBhNl87WIoXO+h+H6uU8f41mM0wyIqw==",
+          "dev": true,
+          "requires": {
+            "doctrine": "0.7.2",
+            "tslib": "1.9.0",
+            "tsutils": "2.8.0"
+          }
+        },
+        "tslint-immutable": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/tslint-immutable/-/tslint-immutable-4.5.4.tgz",
+          "integrity": "sha512-3veFl/wOtAC0pRL8gbAAJiGDgAY40w8Vj3lYg1Cdd2phUhlh/XHsUz1XkludmoydaejZBjxg6+KLfxXwC38X1A==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
+          "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+          "dev": true,
+          "requires": {
+            "tslib": "1.9.0"
+          }
+        }
+      }
+    },
     "@poetapp/frost-client": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@poetapp/frost-client/-/frost-client-0.1.4.tgz",
@@ -2475,9 +2529,9 @@
       }
     },
     "diff": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dir-glob": {
@@ -10891,51 +10945,51 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "commander": "2.12.2",
-        "diff": "3.4.0",
+        "diff": "3.5.0",
         "glob": "7.1.2",
         "js-yaml": "3.7.0",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.5.0",
         "tslib": "1.9.0",
-        "tsutils": "2.20.0"
+        "tsutils": "2.26.2"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10945,25 +10999,6 @@
       "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.7.0.tgz",
       "integrity": "sha512-h8fP8VfFoMOkA/fbPQP5pd4VZfD+LvjkEx48OEWmtObQw8Umj14Ja6NxR4unawE0mq5UbaRPWvn/CcnBg74F5w==",
       "dev": true
-    },
-    "tslint-eslint-rules": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz",
-      "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
-      "dev": true,
-      "requires": {
-        "doctrine": "0.7.2",
-        "tslib": "1.9.0",
-        "tsutils": "1.9.1"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-          "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
-          "dev": true
-        }
-      }
     },
     "tslint-immutable": {
       "version": "4.5.2",
@@ -10982,9 +11017,9 @@
       }
     },
     "tsutils": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.20.0.tgz",
-      "integrity": "sha512-qPOBy1/hwLdBxh/TNIpim5qL1WRMR0tgVGBB6shjnpw6/SuS5ZKYyXXxKDYsMsMtVdFOcL+XPGZVEuc+eCOo4A==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
+      "integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
       "dev": true,
       "requires": {
         "tslib": "1.9.0"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
     "build:staging": "NODE_ENV=staging webpack",
     "build:production": "NODE_ENV=production webpack",
     "lint": "tslint -p ./tsconfig.json",
+    "lint:fix": "tslint -p ./tsconfig.json --fix",
+    "lint:check": "tslint-config-prettier-check ./tslint.json",
     "serve": "ws --spa index.html --rewrite '/api/* -> http://localhost:3000/$1' -d ./dist",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "tslint": "tslint -p ./tsconfig.json --fix",
-    "tslint:check": "tslint-config-prettier-check ./tslint.json",
-    "tslint:compile-rules": "cd tslint-rules && tsc",
     "stylelint": "stylelint './src/**/*.scss' --fix",
     "stylelint:no-fix": "stylelint './src/**/*.scss'",
     "precommit": "lint-staged"
@@ -52,6 +51,7 @@
     "redux-saga": "0.14.8"
   },
   "devDependencies": {
+    "@po.et/tslint-rules": "^1.0.0",
     "@types/babel-core": "6.25.3",
     "@types/classnames": "2.2.3",
     "@types/copy-webpack-plugin": "4.0.1",
@@ -100,9 +100,7 @@
     "stylelint-declaration-use-variable": "1.6.0",
     "stylelint-order": "0.8.1",
     "stylelint-scss": "2.4.0",
-    "tslint": "5.9.1",
     "tslint-config-prettier": "1.7.0",
-    "tslint-eslint-rules": "4.1.1",
     "tslint-immutable": "4.5.2",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "2.3.4",

--- a/tslint.json
+++ b/tslint.json
@@ -1,56 +1,5 @@
 {
-  "linterOptions": {
-      "exclude": [
-        "tslint-rules/src/**/*.ts"
-      ]
-  },
-  "rulesDirectory": ["tslint-plugin-prettier", "tslint-rules/rules"],
   "extends": [
-    "tslint:recommended",
-    "tslint-config-prettier",
-    "tslint-eslint-rules",
-    "tslint-immutable"
-  ],
-  "rules": {
-    "only-arrow-functions": false,
-    "object-literal-sort-keys": false,
-    "no-console": [true],
-    "interface-name": [true, "never-prefix"],
-    "no-namespace": [false],
-    "indent": [true, "spaces", 2],
-    "curly": [true, "as-needed"],
-    "max-line-length": [true, 120],
-    "trailing-comma": false,
-    "arrow-parens": false,
-    "no-empty-interface": false,
-    "member-access": false,
-    "no-var-requires": false,
-    "no-default-export": true,
-    "no-unused-variable": true,
-    "no-shadowed-variable": false,
-    "no-relative-imports": true,
-    "ordered-imports": [
-      true,
-      {
-        "import-sources-order": "lowercase-last",
-        "named-imports-order": "any"
-      }
-    ],
-    "prettier": [true, { 
-      "singleQuote": true,
-      "semi": false
-    }],
-
-    // tslint-immutable Recommended built-in rules
-    "no-var-keyword": true,
-    "no-parameter-reassignment": true,
-    "typedef": [true, "call-signature"],
-    // Immutability rules
-    "readonly-keyword": [true, {"ignore-prefix": "mutable"}],
-    "readonly-array": true,
-    "no-let": true,
-    "no-object-mutation": [true, {"ignore-prefix": ["this.mutable", "mutable"]}],
-    "no-delete": true,
-    "no-method-signature": true
-  }
+    "@po.et/tslint-rules"
+  ]
 }


### PR DESCRIPTION
This commit installs the @po.et/tslint-rules package to standardize
linting across all apps.

It updates package.json with 'lint' and 'lint:fix' commands.

NOTE: This commit does *not* fix any linting errors. That will happen
      in a separate PR.