### PR TITLE
Improve Expired Account Verification Token Message

### DIFF
--- a/src/sagas/VerifiedAccount.saga.ts
+++ b/src/sagas/VerifiedAccount.saga.ts
@@ -52,6 +52,15 @@ function* VerifiedAccount(action: any): SagaIterator {
         className: 'toast',
         autoClose: 2500,
       })
+    } else if (e.includes('Expired token')) {
+      const message =
+        "Sorry! Looks like that link expired. Please login to the API Keys screen and click on the <Resend Email> button. You'll receive a new account verification email."
+      toast.update(toastId, {
+        render: message,
+        type: toast.TYPE.ERROR,
+        className: 'toast',
+        autoClose: false,
+      })
     } else
       toast.update(toastId, {
         render: e,


### PR DESCRIPTION
I wasn't sure if we wanted to change the error message in the frost-api. This is a frost-web change whenever the ExpiredToken error is thrown, we change the wording of the `toast` in `VerifiedAccount.saga`

Progress on #47 