### PR TITLE
Updated Expired Login Token Toast Messages

### DIFF
--- a/src/sagas/CreateApiToken.saga.ts
+++ b/src/sagas/CreateApiToken.saga.ts
@@ -37,9 +37,16 @@ function* GetApiTokens(action: any): SagaIterator {
     yield put(Actions.ApiTokens.onCreateApiTokenError(e))
     yield put(Actions.LoadingPage.onLoadingFull())
     const errorMessage = typeof e === 'object' ? e.message : e
-    toast.error(errorMessage, {
-      className: 'toast',
-      autoClose: 2500,
-    })
+    if (e.includes('Expired token')) {
+      const message = 'Your session has expired. Please logout and login again.'
+      toast.error(message, {
+        className: 'toast',
+        autoClose: 2500,
+      })
+    } else
+      toast.error(errorMessage, {
+        className: 'toast',
+        autoClose: 2500,
+      })
   }
 }

--- a/src/sagas/CreateApiToken.saga.ts
+++ b/src/sagas/CreateApiToken.saga.ts
@@ -1,5 +1,6 @@
 import { Frost } from '@poetapp/frost-client'
 import { Actions } from 'actions/index'
+import { browserHistory } from 'react-router'
 import { SagaIterator, delay } from 'redux-saga'
 import { call, takeLatest, put, ForkEffect } from 'redux-saga/effects'
 const { toast } = require('react-toastify')
@@ -38,7 +39,8 @@ function* GetApiTokens(action: any): SagaIterator {
     yield put(Actions.LoadingPage.onLoadingFull())
     const errorMessage = typeof e === 'object' ? e.message : e
     if (e.includes('Expired token')) {
-      const message = 'Your session has expired. Please logout and login again.'
+      const message = 'Your session has expired. Please login again.'
+      yield put(Actions.SignOut.onSignOut({ redirectLogin: true }))
       toast.error(message, {
         className: 'toast',
         autoClose: 2500,

--- a/src/sagas/CreateApiToken.saga.ts
+++ b/src/sagas/CreateApiToken.saga.ts
@@ -1,6 +1,5 @@
 import { Frost } from '@poetapp/frost-client'
 import { Actions } from 'actions/index'
-import { browserHistory } from 'react-router'
 import { SagaIterator, delay } from 'redux-saga'
 import { call, takeLatest, put, ForkEffect } from 'redux-saga/effects'
 const { toast } = require('react-toastify')

--- a/src/sagas/DeleteApiToken.saga.ts
+++ b/src/sagas/DeleteApiToken.saga.ts
@@ -28,9 +28,16 @@ function* DeleteApiToken(action: any): SagaIterator {
     yield put(Actions.LoadingPage.onLoadingFull())
     yield put(Actions.DeleteApiToken.onDeleteApiTokenError(e))
     const errorMessage = typeof e === 'object' ? e.message : e
-    toast.error(errorMessage, {
-      className: 'toast',
-      autoClose: 2500,
-    })
+    if (e.includes('Expired token')) {
+      const message = 'Your session has expired. Please logout and login again.'
+      toast.error(message, {
+        className: 'toast',
+        autoClose: 2500,
+      })
+    } else
+      toast.error(errorMessage, {
+        className: 'toast',
+        autoClose: 2500,
+      })
   }
 }

--- a/src/sagas/DeleteApiToken.saga.ts
+++ b/src/sagas/DeleteApiToken.saga.ts
@@ -1,6 +1,5 @@
 import { Frost } from '@poetapp/frost-client'
 import { Actions } from 'actions/index'
-import { browserHistory } from 'react-router'
 import { delay, SagaIterator } from 'redux-saga'
 import { call, takeLatest, put, ForkEffect } from 'redux-saga/effects'
 const { toast } = require('react-toastify')

--- a/src/sagas/DeleteApiToken.saga.ts
+++ b/src/sagas/DeleteApiToken.saga.ts
@@ -1,5 +1,6 @@
 import { Frost } from '@poetapp/frost-client'
 import { Actions } from 'actions/index'
+import { browserHistory } from 'react-router'
 import { delay, SagaIterator } from 'redux-saga'
 import { call, takeLatest, put, ForkEffect } from 'redux-saga/effects'
 const { toast } = require('react-toastify')
@@ -29,7 +30,8 @@ function* DeleteApiToken(action: any): SagaIterator {
     yield put(Actions.DeleteApiToken.onDeleteApiTokenError(e))
     const errorMessage = typeof e === 'object' ? e.message : e
     if (e.includes('Expired token')) {
-      const message = 'Your session has expired. Please logout and login again.'
+      const message = 'Your session has expired. Please login again.'
+      yield put(Actions.SignOut.onSignOut({ redirectLogin: true }))
       toast.error(message, {
         className: 'toast',
         autoClose: 2500,


### PR DESCRIPTION
Resolves #59 & #45 

I wasn't able to duplicate the error messages mentioned in these 2 issues. Whenever the login token was expired and I tried to either create or delete  an API token the toast would read "Expired Token"

I updated this toast message to read "Your session has expired. Please logout and login again." 

The actual error is coming from Vault.verifyToken() and the message reads 'bad token', which we are catching in frost-api in the authorization middleware and supplying our own generic expired token error message:
`ExpiredToken: {
    code: 422,
    message: 'Expired token.',
  }`

In the CreateApiToken and DeleteApiToken sagas I look for the error message "Expired token" and change the toast to read the new message.