### PR TITLE
remove context from the toml file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,11 +10,6 @@
   
 # Production context: All deploys to the main
 # repository branch will inherit these settings.
-[context.production]
-  command = "npm run build:production"
-
-[context.qa]
-  command = "npm run build:qa"
 
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.


### PR DESCRIPTION
[PR Process](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-process) - [PR Review Checklist](https://github.com/poetapp/documentation/blob/master/process/pr-review.md#pr-review-checklist)

## Description of Changes

Netlfiy is using context from the netlify.toml over the production build command.

```
10:30:23 AM: Found netlify.toml. Overriding site configuration
10:30:23 AM: Different build command detected, going to use the one specified in the toml file: 'npm run build:production' versus 'npm run build:qa' in the site
```
 By removing the production context, we can then have N amount of Netlify projects for each service required, and abstract the configuration out of the config file, and into the netlify deploy settings directly. Meaning we can have one code base, multiple environments, with no changes to the code. 


### Warning

Merging to `master` automatically triggers a deploy in production.
