### PR TITLE
Update _headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,7 +1,5 @@
-/*
-    Content-Security-Policy: require-sri-for script
-    X-Frame-Options: DENY
-    X-XSS-Protection: 1; mode=block
-    X-Content-Type-Options: nosniff
-    Referrer-Policy: same-origin
-
+Content-Security-Policy: require-sri-for script
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Referrer-Policy: same-origin


### PR DESCRIPTION
Fix issue with Chrome, where site breaks down completely due to JS not loading.

```
Refused to load the script 'https://explorer.poetnetwork.net/app.0b52d506e8d9c3ee39c4.js' because 'require-sri-for' directive requires integrity attribute be present for all scripts.
```